### PR TITLE
Disable pspUseAppArmor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable app armor by default
+
 ## [0.2.1] - 2021-11-03
 
 - Update app metadata

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -3,7 +3,7 @@ rbac:
   ## Use an existing ClusterRole/Role (depending on rbac.namespaced false/true)
   # useExistingRole: name-of-some-(cluster)role
   pspEnabled: true
-  pspUseAppArmor: true
+  pspUseAppArmor: false
   namespaced: false
   extraRoleRules: []
   # - apiGroups: []


### PR DESCRIPTION
`pspUseAppArmor` does not work on our platform and this is also stated in our readme:

> Changes compared to upstream:
> - AppArmor for PSPs is disabled