### PR TITLE
remove -app from app name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ workflows:
       - architect/push-to-app-collection:
           context: "architect"
           name: aws-app-collection
-          app_name: "grafana-app"
+          app_name: "grafana"
           app_namespace: "monitoring"
           app_collection_repo: "aws-app-collection"
           requires:
@@ -47,7 +47,7 @@ workflows:
       - architect/push-to-app-collection:
           context: "architect"
           name: azure-app-collection
-          app_name: "grafana-app"
+          app_name: "grafana"
           app_namespace: "monitoring"
           app_collection_repo: "azure-app-collection"
           requires:
@@ -61,7 +61,7 @@ workflows:
       - architect/push-to-app-collection:
           context: "architect"
           name: kvm-app-collection
-          app_name: "grafana-app"
+          app_name: "grafana"
           app_namespace: "monitoring"
           app_collection_repo: "kvm-app-collection"
           requires:
@@ -75,7 +75,7 @@ workflows:
       - architect/push-to-app-collection:
           context: "architect"
           name: vsphere-app-collection
-          app_name: "grafana-app"
+          app_name: "grafana"
           app_namespace: "monitoring"
           app_collection_repo: "vsphere-app-collection"
           requires:
@@ -89,7 +89,7 @@ workflows:
       - architect/push-to-app-collection:
           context: "architect"
           name: openstack-app-collection
-          app_name: "grafana-app"
+          app_name: "grafana"
           app_namespace: "monitoring"
           app_collection_repo: "openstack-app-collection"
           requires:


### PR DESCRIPTION
remove the -app in app_name since it seems to confusing the app tar ball location in catalog

This aligns with how app-operator is setup ex: https://github.com/giantswarm/app-operator/blob/master/.circleci/config.yml#L106