### PR TITLE
added gcp-app-collection in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,20 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+      
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: gcp-app-collection
+          app_name: "grafana"
+          app_namespace: "monitoring"
+          app_collection_repo: "gcp-app-collection"
+          requires:
+            - control-plane-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 
       #- architect/run-tests-with-ats:
       #    name: execute chart tests


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/24518

circleci configuration did not take gcp into account. Need it to do so to deploy new grafana-app version