### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [2.7.0] - 2023-12-04
 
 ### Changed
@@ -52,7 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - upgrade grafana chart: 6.53.0 => 6.55.1
-
 
 ## [2.3.2] - 2023-04-17
 

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageRegistry: null
+  imageRegistry:
   imagePullSecrets: []
 
 grafana:
@@ -78,7 +78,7 @@ grafana:
   # schedulerName: "default-scheduler"
 
   image:
-    registry: docker.io 
+    registry: gsoci.azurecr.io
     repository: giantswarm/grafana
     # Overrides the Grafana image tag whose default is the chart appVersion
     tag: ""
@@ -96,8 +96,8 @@ grafana:
 
   testFramework:
     enabled: false
-    image: 
-      registry: docker.io
+    image:
+      registry: gsoci.azurecr.io
       repository: giantswarm/bats
       tag: "v1.10.0"
     imagePullPolicy: IfNotPresent
@@ -108,8 +108,7 @@ grafana:
     runAsGroup: 472
     fsGroup: 472
 
-  containerSecurityContext:
-    {}
+  containerSecurityContext: {}
 
   # Enable creating the grafana configmap
   createConfigmap: true
@@ -136,7 +135,7 @@ grafana:
   # priorityClassName:
 
   downloadDashboardsImage:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/curl
     tag: 8.4.0
     sha: ""
@@ -337,7 +336,7 @@ grafana:
     ## initChownData container image
     ##
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/busybox
       tag: "1.36.1"
       sha: ""
@@ -688,7 +687,8 @@ grafana:
     grafana_net:
       url: https://grafana.net
     server:
-      domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ end }}"
+      domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts
+        | first }}{{ end }}"
   ## grafana Authentication can be enabled with the following values on grafana.ini
   # server:
         # The full public facing url you use in browser, used for redirects and emails
@@ -741,7 +741,7 @@ grafana:
   ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
   sidecar:
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/k8s-sidecar
       tag: 1.25.3
       sha: ""
@@ -772,20 +772,20 @@ grafana:
       # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
       folder: /tmp/dashboards
       # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
-      defaultFolderName: null
+      defaultFolderName:
       # Namespaces list. If specified, the sidecar will search for config-maps/secrets inside these namespaces.
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces.
-      searchNamespace: null
+      searchNamespace:
       # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
       watchMethod: WATCH
       # search in configmap, secret or both
       resource: both
       # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
       # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
-      folderAnnotation: null
+      folderAnnotation:
       # Absolute path to shell script to execute after a configmap got reloaded
-      script: null
+      script:
       # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
       # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
       # watchServerTimeout: 3600
@@ -825,7 +825,7 @@ grafana:
       # If specified, the sidecar will search for datasource config-maps inside this namespace.
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces
-      searchNamespace: null
+      searchNamespace:
       # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
       watchMethod: WATCH
       # search in configmap, secret or both
@@ -847,7 +847,7 @@ grafana:
       # If specified, the sidecar will search for plugin config-maps inside this namespace.
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces
-      searchNamespace: null
+      searchNamespace:
       # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
       watchMethod: WATCH
       # search in configmap, secret or both
@@ -867,7 +867,7 @@ grafana:
       # If specified, the sidecar will search for notifier config-maps inside this namespace.
       # Otherwise the namespace in which the sidecar is running will be used.
       # It's also possible to specify ALL to search in all namespaces
-      searchNamespace: null
+      searchNamespace:
       # search in configmap, secret or both
       resource: both
       # Sets the size limit of the notifier sidecar emptyDir volume
@@ -887,7 +887,7 @@ grafana:
     enabled: false
     replicas: 1
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       # image-renderer Image repository
       repository: giantswarm/grafana-image-renderer
       # image-renderer Image tag


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
