### PR TITLE
Add ingress to grafana CNP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `CiliumNetworkPolicy` to allow cluster ingress (for e.g. Prometheus).
+- 
 ## [2.10.0] - 2024-02-09
 
 ### Changed

--- a/helm/grafana/templates/cilium-network-policy.yaml
+++ b/helm/grafana/templates/cilium-network-policy.yaml
@@ -15,4 +15,7 @@ spec:
         - kube-apiserver
         - cluster
         - world
+  ingress:
+    - fromEntities:
+      - cluster
 {{- end -}}


### PR DESCRIPTION
This PR adds ingress from the cluster containers to grafana so prometheus can access grafana but also the grafana permissions job