### PR TITLE
Fix CI jobs generating new releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,6 @@ workflows:
     jobs:
       - template-chart:
           name: "template-chart"
-          filters:
-            branches:
-              ignore:
-                - master
 
       - architect/push-to-app-catalog:
           context: "architect"
@@ -50,14 +46,14 @@ workflows:
               only: /^v.*/
           requires:
             - "template-chart"
-      
+
       - architect/run-tests-with-ats:
           name: run-chart-tests-with-ats
           filters:
-            # Do not trigger the job on merge to master.
+            # Do not trigger the job on merge to main.
             branches:
               ignore:
-                - master
+                - main
           requires:
             - "app-catalog"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix CI jobs generating new releases
+
 ## [2.16.0] - 2024-10-07
 
 ### Changed


### PR DESCRIPTION
Last successful release was 2.14.
After that, release generation was broken.

This PR should fix CircleCI release generation.