### PR TITLE
Add Ingress dummy paths to block access to the `/swagger`, `/metrics`, and `/api/health` endpoints by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add an nginx deny rule to block access to the `/swagger` endpoint by default.
+
+### Changed
+
 - upgrade grafana chart: 8.5.12 => 8.6.0
 
 ## [2.17.0] - 2024-11-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add an nginx deny rule to block access to the `/swagger` endpoint by default.
+- Add Ingress dummy paths to block access to the `/swagger`, `/metrics`, and `/api/health` endpoints by default.
 
 ### Changed
 

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -212,6 +212,11 @@ grafana:
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        location /swagger {
+          deny all;
+          return 403;
+        }
     labels: {}
     path: /
 

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -209,7 +209,7 @@ grafana:
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
     # ingressClassName: nginx
     # Values can be templated
-    annotations: {}
+    annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/helm/grafana/values.yaml
+++ b/helm/grafana/values.yaml
@@ -209,14 +209,9 @@ grafana:
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
     # ingressClassName: nginx
     # Values can be templated
-    annotations:
+    annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        location /swagger {
-          deny all;
-          return 403;
-        }
     labels: {}
     path: /
 
@@ -226,7 +221,7 @@ grafana:
     hosts:
       - chart-example.local
     ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
-    extraPaths: []
+    extraPaths:
     # - path: /*
     #   backend:
     #     serviceName: ssl-redirect
@@ -239,6 +234,29 @@ grafana:
     #       name: ssl-redirect
     #       port:
     #         name: use-annotation
+    #
+    # Disable some paths by default
+      - path: /swagger
+        pathType: Prefix
+        backend:
+          service:
+            name: none
+            port:
+              number: 1111
+      - path: /metrics
+        pathType: Prefix
+        backend:
+          service:
+            name: none
+            port:
+              number: 1111
+      - path: /api/health
+        pathType: Prefix
+        backend:
+          service:
+            name: none
+            port:
+              number: 1111
 
 
     tls: []


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31448

This PR adds a deny rule to the nginx configuration for the /swagger endpoint. This is to prevent Swagger queryConfig malicious usage, see https://github.com/swagger-api/swagger-ui/issues/4332.

This makes our values file drift from upstream, and make future upgrade more "complex" but that change is aimed at improving default security settings.