### PR TITLE
helm schema now accepts array for env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- helm schema now accepts array for `env`
+
 ## [2.18.0] - 2024-12-03
 
 ### Changed

--- a/helm/grafana/values.schema.json
+++ b/helm/grafana/values.schema.json
@@ -85,7 +85,7 @@
                     "type": "object",
                     "properties": {
                         "env": {
-                            "type": "object"
+                            "type": ["object", "array"]
                         },
                         "envFromSecret": {
                             "type": "string"
@@ -122,7 +122,7 @@
                     "type": "boolean"
                 },
                 "env": {
-                    "type": "object"
+                    "type": ["object", "array"]
                 },
                 "envFromConfigMaps": {
                     "type": "array"
@@ -131,7 +131,7 @@
                     "type": "string"
                 },
                 "envFromSecrets": {
-                    "type": "array"
+                    "type": ["object", "array"]
                 },
                 "envRenderSecret": {
                     "type": "object"
@@ -696,7 +696,7 @@
                                     "type": "boolean"
                                 },
                                 "env": {
-                                    "type": "object"
+                                    "type": ["object", "array"]
                                 },
                                 "extraMounts": {
                                     "type": "array"


### PR DESCRIPTION
Noticed the problem when working on grafana setup with postgresql (ref: https://github.com/giantswarm/giantswarm/issues/32423)