### PR TITLE
fix recovery test IAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update recovery-test AWS IAM to support unique names
+
 ## [2.36.1] - 2026-04-01
 
 ### Fixed

--- a/helm/grafana/templates/cnpg/crossplane/aws/iam.yaml
+++ b/helm/grafana/templates/cnpg/crossplane/aws/iam.yaml
@@ -50,8 +50,8 @@ spec:
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
-              "StringEquals": {
-                "{{ $oidcProvider }}:sub": "system:serviceaccount:{{ $namespace }}:grafana-postgresql-recovery-test",
+              "StringLike": {
+                "{{ $oidcProvider }}:sub": "system:serviceaccount:{{ $namespace }}:grafana-postgresql-recovery-test-*",
                 "{{ $oidcProvider }}:aud": "sts.amazonaws.com{{- if $isChinaRegion }}.cn{{- end }}"
               }
             }


### PR DESCRIPTION
Tests are failing because each test creates a new serviceaccount (see https://github.com/giantswarm/giantswarm/issues/33600) with a unique name, but AWS IAM was granting a fixed name.
This PR updates the AWS role so that all `grafana-postgresql-recovery-test-*` accounts are allowed to access postgresql buckets.