### PR TITLE
Keep crossplane storage no matter what

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade grafana chart: 11.3.6 => 11.3.7
 - Upgrade pg-cluster-recovery-test subchart: v0.4.1 => v0.5.0
 
+### Fixed
+
+- Make sure crossplane cannot delete Crossplane azure storage accounts/containers and s3 buckets.
+
 ## [2.36.2] - 2026-04-03
 
 ### Fixed

--- a/helm/grafana/templates/cnpg/crossplane/aws/bucket.yaml
+++ b/helm/grafana/templates/cnpg/crossplane/aws/bucket.yaml
@@ -20,7 +20,7 @@ spec:
     - Observe
     {{- else }}
     - "Create"
-    - "Delete"
+    - "Update"
     - "LateInitialize"
     - "Observe"
     {{- end }}

--- a/helm/grafana/templates/cnpg/crossplane/aws/bucket.yaml
+++ b/helm/grafana/templates/cnpg/crossplane/aws/bucket.yaml
@@ -19,7 +19,10 @@ spec:
     {{- if .Values.postgresqlCluster.crossplane.observeOnly }}
     - Observe
     {{- else }}
-    - "*"
+    - "Create"
+    - "Delete"
+    - "LateInitialize"
+    - "Observe"
     {{- end }}
   forProvider:
     forceDestroy: false

--- a/helm/grafana/templates/cnpg/crossplane/azure/account.yaml
+++ b/helm/grafana/templates/cnpg/crossplane/azure/account.yaml
@@ -34,7 +34,7 @@ spec:
     - Observe
     {{- else }}
     - "Create"
-    - "Delete"
+    - "Update"
     - "LateInitialize"
     - "Observe"
     {{- end }}

--- a/helm/grafana/templates/cnpg/crossplane/azure/account.yaml
+++ b/helm/grafana/templates/cnpg/crossplane/azure/account.yaml
@@ -33,7 +33,10 @@ spec:
     {{- if .Values.postgresqlCluster.crossplane.observeOnly }}
     - Observe
     {{- else }}
-    - "*"
+    - "Create"
+    - "Delete"
+    - "LateInitialize"
+    - "Observe"
     {{- end }}
   providerConfigRef:
     name: {{ .Values.postgresqlCluster.crossplane.providerConfigRef }}

--- a/helm/grafana/templates/cnpg/crossplane/azure/container.yaml
+++ b/helm/grafana/templates/cnpg/crossplane/azure/container.yaml
@@ -27,7 +27,7 @@ spec:
     - Observe
     {{- else }}
     - "Create"
-    - "Delete"
+    - "Update"
     - "LateInitialize"
     - "Observe"
     {{- end }}

--- a/helm/grafana/templates/cnpg/crossplane/azure/container.yaml
+++ b/helm/grafana/templates/cnpg/crossplane/azure/container.yaml
@@ -26,7 +26,10 @@ spec:
     {{- if .Values.postgresqlCluster.crossplane.observeOnly }}
     - Observe
     {{- else }}
-    - "*"
+    - "Create"
+    - "Delete"
+    - "LateInitialize"
+    - "Observe"
     {{- end }}
   providerConfigRef:
     name: {{ .Values.postgresqlCluster.crossplane.providerConfigRef }}


### PR DESCRIPTION
We had and incident during the night causing issues with Crossplane resources.
Let's make sure that even if we delete the crossplane resources, object storage is kept