### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
           chart: "grafana"
           persist_chart_archive: true
           ct_config: ".circleci/ct-config.yaml"
+          override_app_version: false
           # Trigger job on git tag.
           filters:
             tags:
@@ -44,6 +45,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "grafana"
           ct_config: ".circleci/ct-config.yaml"
+          override_app_version: false
           # Trigger job on git tag.
           filters:
             tags:
@@ -60,4 +62,3 @@ workflows:
                 - main
           requires:
             - "app-catalog"
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [2.38.0] - 2026-05-05
 
 ### Changed


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.