### PR TITLE
chore: remove `ct_config` from push-to-app-catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ workflows:
           app_catalog_test: "giantswarm-test-catalog"
           chart: "grafana"
           persist_chart_archive: true
-          ct_config: ".circleci/ct-config.yaml"
           override_app_version: false
           # Trigger job on git tag.
           filters:
@@ -44,7 +43,6 @@ workflows:
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "grafana"
-          ct_config: ".circleci/ct-config.yaml"
           override_app_version: false
           # Trigger job on git tag.
           filters:


### PR DESCRIPTION
`ct_config` has been **ignored by architect-orb since v9.0.0 (when the `helm-lint` step it controlled was removed)** — passing it currently does nothing.

It is removed in the upcoming **architect-orb v10.0.0**. Because CircleCI fails config compilation on unknown job arguments, any repo still passing it will break the moment Renovate bumps the orb to v10. Merging this beforehand makes that bump a no-op for you.

No behaviour change: the parameter is already a no-op today.

Part of giantswarm/roadmap#4066