### PR TITLE
fix: trim a trailing dot from the helm.sh/chart label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Trim trailing `.` from the `helm.sh/chart` label, to fix build.
+
 ## [2.40.0] - 2026-08-24
 
 ### Added

--- a/helm/grafana/templates/_helpers.tpl
+++ b/helm/grafana/templates/_helpers.tpl
@@ -18,9 +18,14 @@ application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.appli
 
 {{/*
 Create chart name and version as used by the chart label.
+
+CI stamps a dev version built from the branch name, which can push this past the
+63 character label limit. Truncating there can leave a trailing character that is
+not allowed at the end of a label value, so trim those - the API server rejects
+the object otherwise.
 */}}
 {{- define "grafana.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Some more `run-chart-tests-with-ats` failures due to trailing characters in chart version.

CI stamps the chart version from the branch name, and for a long branch name that string is already 63 characters:

```
2.40.1-dev.renovate-architect-10-x.2026-08-24.13-57-38.he61d0e0
```

`grafana.chart` truncates `grafana-<version>` to 63 characters, which leaves a trailing `.`:

```
helm.sh/chart: grafana-2.40.1-dev.renovate-architect-10-x.2026-08-24.13-57-38.
```

`| trimSuffix "."` after the existing `trimSuffix "-"` fixes it. Rendered with the version above, the label comes out as a valid 62 character value and no other label in the chart is invalid.

This branch's own stamped version also hits 63 characters, so its ATS run exercises the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
